### PR TITLE
fix: Replace undici fetch with request to remove experimental warnings

### DIFF
--- a/.changeset/ten-bags-burn.md
+++ b/.changeset/ten-bags-burn.md
@@ -1,0 +1,5 @@
+---
+"@nicktomlin/mono-http": patch
+---
+
+Replace Undici 'fetch' with 'request' to remove experimental warnings

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,8 +1,8 @@
-import {fetch} from 'undici';
+import {request} from 'undici';
 
 export class Client {
   async run () {
-    const res = await fetch('https://httpbin.org/get')
-    return res.json()
+    const {body} = await request('https://httpbin.org/get')
+    return body.json()
   }
 }


### PR DESCRIPTION
Undici's `fetch` impl depends on certain experimental globals (e.g. Blob) that result in the following warning on node 16.x

```
(node:64649) ExperimentalWarning: buffer.Blob is an experimental feature. This feature could change at any time
```

This migrates to `request` for the time being to avoid this warning.